### PR TITLE
add the InjectedXrayBar event.

### DIFF
--- a/src/Events/InjectedXrayBar.php
+++ b/src/Events/InjectedXrayBar.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BeyondCode\ViewXray\Events;
+
+use Illuminate\Http\Response;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class InjectedXrayBar
+{
+    use SerializesModels;
+
+    /** @var Response */
+    private $response;
+
+    public function __construct(Response $response)
+    {
+        $this->response = $response;
+    }
+
+    /**
+     * @return Response
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+}

--- a/src/XrayMiddleware.php
+++ b/src/XrayMiddleware.php
@@ -2,6 +2,7 @@
 
 namespace BeyondCode\ViewXray;
 
+use BeyondCode\ViewXray\Events\InjectedXrayBar;
 use Closure;
 
 class XrayMiddleware
@@ -114,5 +115,7 @@ class XrayMiddleware
         // Update the new content and reset the content length
         $response->setContent($content);
         $response->headers->remove('Content-Length');
+
+        event(new InjectedXrayBar($response));
     }
 }

--- a/tests/XrayTest.php
+++ b/tests/XrayTest.php
@@ -4,6 +4,8 @@ namespace BeyondCode\ViewXray\Tests;
 
 use Route;
 use Spatie\Snapshots\MatchesSnapshots;
+use BeyondCode\ViewXray\Events\InjectedXrayBar;
+use Illuminate\Support\Facades\Event;
 
 class XrayTest extends TestCase
 {
@@ -45,5 +47,37 @@ class XrayTest extends TestCase
         $response = $this->get('/');
         
         $this->assertMatchesSnapshot($response->getContent());
+    }
+    
+    /** @test */
+    public function it_fires_an_event_if_injected_xray_bar()
+    {
+        Event::fake();
+
+        Route::get('/', function () {
+            return view('example');
+        });
+
+        $this->get('/');
+
+        Event::assertDispatched(InjectedXrayBar::class);
+    }
+
+    /** @test */
+    public function it_does_not_fire_an_event_if_injected_xray_bar()
+    {
+        Event::fake();
+
+        $data = [
+            'foo' => 'bar'
+        ];
+
+        Route::get('/', function () use ($data) {
+            return $data;
+        });
+
+        $this->get('/');
+
+        Event::assertNotDispatched(InjectedXrayBar::class);
     }
 }


### PR DESCRIPTION
When a JavaScript file is added to the xray bar, we want to add our own custom JavaScript file on our end.

The JavaScript code we want to add is as follows:

```js
$('body').on('click', '.xray-specimen-handle.Specimen', function(e) {
  const $specimen = $(e.target).closest('.xray-specimen.Specimen');
  const title = $specimen.attr('title');

  const apiUrl = `http://localhost:63342/api/file/${title}`;
  window.open(apiUrl);
});

```

 Clicking on the part of the image highlighted below will display the corresponding view file in the IDE.

![스크린샷 2023-02-25 오전 4 16 45](https://user-images.githubusercontent.com/54769955/221272254-ae242dc5-ad15-447c-9336-95999fdada37.png)


Therefore, when a JavaScript file is added to the xray bar, we want to trigger the event shown below.

```php
<?php

// This is the XrayMiddleware class.

protected function injectXrayBar($response)
{
    
    // The existing code.
    event(new InjectedXrayBar($response));
}
```

```php
<?php

namespace BeyondCode\ViewXray\Events;

use Illuminate\Http\Response;
use Illuminate\Queue\SerializesModels;
use Illuminate\Support\Collection;

class InjectedXrayBar
{
    use SerializesModels;

    /** @var Response */
    private $response;

    public function __construct(Response $response)
    {
        $this->response = $response;
    }

    /**
     * @return Response
     */
    public function getResponse()
    {
        return $this->response;
    }
}
```